### PR TITLE
self.options always undefined.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -251,7 +251,7 @@
 	 */
 	Segmenter.prototype._renderPiece = function(piece) {
 		var idx = this.pieces.indexOf(piece);
-
+		var self = this;
 		if( self.options.animation.translateZ != undefined ) {
 			if( typeof self.options.animation.translateZ === 'object' ) {
 				var randArr = createRandIntOrderedArray(self.options.animation.translateZ.min, self.options.animation.translateZ.max, self.options.pieces);


### PR DESCRIPTION
Undefined self = window, so self.options is always undefined.

A bug i saw when converting to TypeScript. Tested in browser to confirm that self was the same as window, not this (self is a global refference to window.)